### PR TITLE
Remove useless python 'asyncio' requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/mathieu-mp/intex-spa",
     packages=find_packages(),
-    install_requires=["asyncio"],
+    install_requires=[],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
'asyncio' was moved long ago to python built-in library