### PR TITLE
Fix: Checksum algorithm shall force 0x00 value to 0xFF

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/intex_spa/intex_spa_query.py
+++ b/intex_spa/intex_spa_query.py
@@ -56,6 +56,7 @@ def checksum_as_int(data: str) -> int:
             int("0x" + data[index : index + 2], 16)
         )
     calculated_checksum = calculated_checksum % 0xFF
+    # Fix: https://github.com/mathieu-mp/intex-spa/issues/27
     if calculated_checksum == 0x00:
         calculated_checksum = 0xFF
     return calculated_checksum

--- a/intex_spa/intex_spa_query.py
+++ b/intex_spa/intex_spa_query.py
@@ -55,13 +55,16 @@ def checksum_as_int(data: str) -> int:
         calculated_checksum = calculated_checksum - (
             int("0x" + data[index : index + 2], 16)
         )
-    return calculated_checksum % 0xFF
+    calculated_checksum = calculated_checksum % 0xFF
+    if calculated_checksum == 0x00:
+        calculated_checksum = 0xFF
+    return calculated_checksum
 
 
 def checksum_as_str(data: str) -> str:
     """Return string checksum for the given data, as expected by Intex Spa protocol"""
     # Return checksum as a hex string without 0x prefix
-    return hex(checksum_as_int(data) % 0xFF)[2:].upper()
+    return hex(checksum_as_int(data))[2:].upper()
 
 
 class IntexSpaQuery:

--- a/tests/test_intex_spa_query_checksum.py
+++ b/tests/test_intex_spa_query_checksum.py
@@ -1,0 +1,32 @@
+from intex_spa.intex_spa_query import IntexSpaQuery
+
+valid_status_responses = [
+    b'{"sid":"12345678901234","data":"FFFF110F010700220000000080808022000012","result":"ok","type":2}\n',
+    b'{"sid":"12345678901234","data":"FFFF110F010700B50000000080808022000012","result":"ok","type":2}\n',
+    b'{"sid":"12345678901234","data":"FFFF110F0107006400000085808085670000FF","result":"ok","type":2}\n',  # From https://github.com/mathieu-mp/intex-spa/issues/27
+    b'{"sid":"12345678901234","data":"FFFF110F01070064000000008080806700008A","result":"ok","type":2}\n',  # From https://github.com/mathieu-mp/intex-spa/issues/27
+]
+invalid_status_responses = [
+    b'{"sid":"12345678901234","data":"FFFF110F010700220000000080808022000044","result":"ok","type":2}\n',  # Arbitrary false checksum
+    b'{"sid":"12345678901234","data":"00000000000000000000000000000000000000","result":"ok","type":2}\n',  # Checksum 0x00 means no checksum calculation
+]
+
+
+def test_valid_intex_spa_checksums():
+    query = IntexSpaQuery(intent="status")
+    query.intex_timestamp = "12345678901234"
+    for status_response in valid_status_responses:
+        try:
+            query.render_response_data(received_bytes=status_response)
+        except Exception as exc:
+            assert False, f"str(status_response) raised an exception {exc}"
+
+
+def test_invalid_intex_spa_checksums():
+    query = IntexSpaQuery(intent="status")
+    query.intex_timestamp = "12345678901234"
+    for status_response in invalid_status_responses:
+        try:
+            query.render_response_data(received_bytes=status_response)
+        except AssertionError as exc:
+            assert True, f"str(status_response) raised an exception {exc}"

--- a/tests/test_intex_spa_query_checksum.py
+++ b/tests/test_intex_spa_query_checksum.py
@@ -1,10 +1,11 @@
 from intex_spa.intex_spa_query import IntexSpaQuery
 
+import pytest
+
 valid_status_responses = [
     b'{"sid":"12345678901234","data":"FFFF110F010700220000000080808022000012","result":"ok","type":2}\n',
-    b'{"sid":"12345678901234","data":"FFFF110F010700B50000000080808022000012","result":"ok","type":2}\n',
-    b'{"sid":"12345678901234","data":"FFFF110F0107006400000085808085670000FF","result":"ok","type":2}\n',  # From https://github.com/mathieu-mp/intex-spa/issues/27
     b'{"sid":"12345678901234","data":"FFFF110F01070064000000008080806700008A","result":"ok","type":2}\n',  # From https://github.com/mathieu-mp/intex-spa/issues/27
+    b'{"sid":"12345678901234","data":"FFFF110F0107006400000085808085670000FF","result":"ok","type":2}\n',  # From https://github.com/mathieu-mp/intex-spa/issues/27
 ]
 invalid_status_responses = [
     b'{"sid":"12345678901234","data":"FFFF110F010700220000000080808022000044","result":"ok","type":2}\n',  # Arbitrary false checksum
@@ -12,21 +13,16 @@ invalid_status_responses = [
 ]
 
 
-def test_valid_intex_spa_checksums():
+@pytest.mark.parametrize("status_response", valid_status_responses)
+def test_valid_intex_spa_checksums(status_response):
     query = IntexSpaQuery(intent="status")
     query.intex_timestamp = "12345678901234"
-    for status_response in valid_status_responses:
-        try:
-            query.render_response_data(received_bytes=status_response)
-        except Exception as exc:
-            assert False, f"str(status_response) raised an exception {exc}"
+    query.render_response_data(received_bytes=status_response)
 
 
-def test_invalid_intex_spa_checksums():
+@pytest.mark.parametrize("status_response", invalid_status_responses)
+def test_invalid_intex_spa_checksums(status_response):
     query = IntexSpaQuery(intent="status")
     query.intex_timestamp = "12345678901234"
-    for status_response in invalid_status_responses:
-        try:
-            query.render_response_data(received_bytes=status_response)
-        except AssertionError as exc:
-            assert True, f"str(status_response) raised an exception {exc}"
+    with pytest.raises(AssertionError):
+        query.render_response_data(received_bytes=status_response)


### PR DESCRIPTION
0x00 checksum value is reserved for "checksum not calculated" and should be forced to 0xFF